### PR TITLE
Fix touch handler cancelling connection timeout

### DIFF
--- a/app/src/main/java/com/maticcm/openwebuiclient/WebViewActivity.kt
+++ b/app/src/main/java/com/maticcm/openwebuiclient/WebViewActivity.kt
@@ -1039,14 +1039,12 @@ class WebViewActivity : AppCompatActivity() {
                 if (activePointers.size < REQUIRED_FINGERS) {
                     isLongPressing = false
                     hideLongPressIndicator()
-                    timeoutHandler.removeCallbacksAndMessages(null)
                 }
             }
             MotionEvent.ACTION_CANCEL -> {
                 activePointers.clear()
                 isLongPressing = false
                 hideLongPressIndicator()
-                timeoutHandler.removeCallbacksAndMessages(null)
             }
         }
         return false


### PR DESCRIPTION
## What

In `handleTouchEvent`, both `ACTION_POINTER_UP` and `ACTION_CANCEL` were calling `timeoutHandler.removeCallbacksAndMessages(null)`. This is a broad call that removes **all** pending callbacks on the handler — including the 30-second connection timeout runnable (`timeoutRunnable`).

The result: any touch on the screen during page load silently cancels the timeout. If the server is unreachable the progress bar spins indefinitely and the connection error is never shown.

## Root cause

`timeoutHandler` is shared between two concerns:
1. The connection timeout (`timeoutRunnable`) — posted in `setupWebView`
2. The 4-finger long-press progress updates (`progressUpdateRunnable`) — posted in `startProgressUpdate`

The touch handler should only ever cancel the long-press progress runnable, not the connection timeout. `hideLongPressIndicator()` (called on the same lines) already does this correctly via a targeted `removeCallbacks(progressUpdateRunnable)`. The two `removeCallbacksAndMessages(null)` calls were redundant and harmful.

## Fix

Remove the two `removeCallbacksAndMessages(null)` calls from `handleTouchEvent`. The long-press runnable is already cleaned up by `hideLongPressIndicator()`.

## No conflict with open PRs

This touches `handleTouchEvent` (~line 1039), which is in a completely separate hunk from any other open PRs against this file.