### PR TITLE
Validate server URL scheme before saving in setup

### DIFF
--- a/app/src/main/java/com/maticcm/openwebuiclient/IpInputActivity.kt
+++ b/app/src/main/java/com/maticcm/openwebuiclient/IpInputActivity.kt
@@ -45,6 +45,11 @@ class IpInputActivity : AppCompatActivity() {
                 return@setOnClickListener
             }
 
+            if (!url.startsWith("http://") && !url.startsWith("https://")) {
+                showError("URL must start with http:// or https://")
+                return@setOnClickListener
+            }
+
             // Save the URL and mark setup as complete
             getSharedPreferences("AppPrefs", MODE_PRIVATE)
                 .edit()


### PR DESCRIPTION
## What

The server URL entry screen only checked for an empty field. Any freeform text — a bare IP address, a hostname without a scheme, a typo — was saved and navigated to immediately, dropping the user into a silent white screen with no indication of what went wrong.

## Fix

Adds a scheme check before saving: if the URL doesn't start with `http://` or `https://`, the existing inline error view shows a clear message.

A full regex check is intentionally not used here — users commonly connect to local IPs (`192.168.x.x`), Tailscale/VPN domains, and other hosts that don't have a public TLD, which would be incorrectly rejected by the stricter pattern in `WebViewActivity`.

## No conflict with open PRs

Only touches `IpInputActivity.kt`, which no other open PR modifies.