### PR TITLE
Show connection error page with retry instead of blank screen

### DIFF
--- a/app/src/main/java/com/maticcm/openwebuiclient/WebViewActivity.kt
+++ b/app/src/main/java/com/maticcm/openwebuiclient/WebViewActivity.kt
@@ -696,7 +696,27 @@ class WebViewActivity : AppCompatActivity() {
 
     private fun showConnectionError() {
         Log.e("WebViewActivity", "Connection failed or timed out")
-        binding.webView.loadUrl("about:blank")
+        binding.progressBar.isVisible = false
+        val displayUrl = android.text.Html.escapeHtml(baseUrl)
+        val html = """
+            <html>
+            <head>
+                <meta name="viewport" content="width=device-width, initial-scale=1">
+                <style>
+                    body { font-family: sans-serif; display: flex; flex-direction: column; align-items: center; justify-content: center; min-height: 100vh; margin: 0; background: #111827; color: #e5e7eb; text-align: center; padding: 24px; box-sizing: border-box; }
+                    h2 { margin: 0 0 8px; }
+                    .url { color: #9ca3af; word-break: break-all; margin-bottom: 24px; }
+                    .retry { padding: 12px 32px; background: #3b82f6; color: white; border-radius: 8px; text-decoration: none; font-size: 16px; }
+                </style>
+            </head>
+            <body>
+                <h2>Connection failed</h2>
+                <p class="url">$displayUrl</p>
+                <a class="retry" href="$baseUrl">Retry</a>
+            </body>
+            </html>
+        """.trimIndent()
+        binding.webView.loadDataWithBaseURL(baseUrl, html, "text/html", "UTF-8", null)
     }
 
     private fun handleIntent(intent: Intent) {


### PR DESCRIPTION
## What

When the WebView failed to connect or timed out, `showConnectionError()` loaded `about:blank`. The user saw a white screen with no explanation and no way to recover short of force-closing the app and re-entering the URL. This is the main symptom reported in #12.

## Fix

Replaces `about:blank` with an inline HTML error page (dark background to match Open WebUI's theme) that shows:
- The server URL that failed to load
- A **Retry** link that reloads the same URL

Also explicitly hides the progress bar in `showConnectionError()` — `onReceivedError` calls this function without hiding it first, so the spinner was left visible over the blank page.

## No conflict with open PRs

Touches only `showConnectionError()` (~line 697 in `WebViewActivity.kt`), well outside the hunks modified by any other open PR.