### PR TITLE
Fix camera not launching on Android 11+ (resolveActivity returns null)

### DIFF
--- a/app/src/main/java/com/maticcm/openwebuiclient/WebViewActivity.kt
+++ b/app/src/main/java/com/maticcm/openwebuiclient/WebViewActivity.kt
@@ -1154,23 +1154,12 @@ class WebViewActivity : AppCompatActivity() {
                 imageFile
             )
             Log.d("WebViewActivity", "Created camera URI: $cameraImageUri")
-
-            // Grant URI permissions
-            val takePictureIntent = Intent(MediaStore.ACTION_IMAGE_CAPTURE).apply {
-                putExtra(MediaStore.EXTRA_OUTPUT, cameraImageUri)
-                addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
-                addFlags(Intent.FLAG_GRANT_WRITE_URI_PERMISSION)
-            }
-
-            // Check if there's a camera app available
-            if (takePictureIntent.resolveActivity(packageManager) != null) {
-                cameraLauncher.launch(cameraImageUri)
-                Log.d("WebViewActivity", "Launched camera")
-            } else {
-                Log.e("WebViewActivity", "No camera app available")
-                filePathCallback?.onReceiveValue(null)
-                filePathCallback = null
-            }
+            cameraLauncher.launch(cameraImageUri)
+            Log.d("WebViewActivity", "Launched camera")
+        } catch (e: android.content.ActivityNotFoundException) {
+            Log.e("WebViewActivity", "No camera app available", e)
+            filePathCallback?.onReceiveValue(null)
+            filePathCallback = null
         } catch (e: Exception) {
             Log.e("WebViewActivity", "Error launching camera", e)
             filePathCallback?.onReceiveValue(null)


### PR DESCRIPTION
## What

The camera capture button in Open WebUI (issue #13) silently does nothing on Android 11+.

## Root cause

`launchCamera()` was using `resolveActivity()` to check whether a camera app was available before launching. Since Android 11 (API 30), package visibility restrictions mean `resolveActivity()` with an implicit intent returns `null` unless a matching `<queries>` entry is present in the manifest — even when a camera app is installed. The code always hit the `else` branch, immediately called `filePathCallback?.onReceiveValue(null)`, and the file chooser was dismissed with no camera ever opening.

There was also a secondary issue: the `takePictureIntent` built inside `launchCamera()` was dead code. It was constructed with `EXTRA_OUTPUT` and URI permission flags but never launched — `ActivityResultContracts.TakePicture` creates its own intent internally when `cameraLauncher.launch()` is called, so those flags never applied.

## Fix

Remove the dead `takePictureIntent` and the `resolveActivity` guard. The correct modern pattern is to attempt the launch and catch `ActivityNotFoundException` for the no-camera case, which is what the existing `Exception` block would have handled anyway.

## No conflict with open PRs

Only touches `launchCamera()` in `WebViewActivity.kt`, well outside the hunks modified by any other open PR.

Closes #13